### PR TITLE
Update Codewind devfiles for 0.6.0

### DIFF
--- a/devfiles/goTemplate/devfile.yaml
+++ b/devfiles/goTemplate/devfile.yaml
@@ -10,11 +10,22 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+  - alias: go-plugin
+    type: chePlugin
+    id: ms-vscode/go/0.11.4
+    memoryLimit: 512Mi
+  - alias: java-plugin
+    type: chePlugin
+    id: redhat/java11/0.50.0
+    memoryLimit: 512Mi
+  - type: chePlugin
+    id: che-incubator/typescript/1.35.1 
+    memoryLimit: 512Mi
   

--- a/devfiles/goTemplate/devfile.yaml
+++ b/devfiles/goTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
   - alias: go-plugin
     type: chePlugin
     id: ms-vscode/go/0.11.4

--- a/devfiles/javaMicroProfileTemplate/devfile.yaml
+++ b/devfiles/javaMicroProfileTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/javaMicroProfileTemplate/devfile.yaml
+++ b/devfiles/javaMicroProfileTemplate/devfile.yaml
@@ -10,11 +10,14 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+  - alias: java-plugin
+    type: chePlugin
+    id: redhat/java11/0.50.0
   

--- a/devfiles/lagomJavaTemplate/devfile.yaml
+++ b/devfiles/lagomJavaTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/lagomJavaTemplate/devfile.yaml
+++ b/devfiles/lagomJavaTemplate/devfile.yaml
@@ -10,11 +10,14 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+  - alias: java-plugin
+    type: chePlugin
+    id: redhat/java11/0.50.0
   

--- a/devfiles/nodeExpressTemplate/devfile.yaml
+++ b/devfiles/nodeExpressTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
   - type: chePlugin
     id: che-incubator/typescript/1.35.1 
     memoryLimit: 512Mi

--- a/devfiles/nodeExpressTemplate/devfile.yaml
+++ b/devfiles/nodeExpressTemplate/devfile.yaml
@@ -10,11 +10,14 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+  - type: chePlugin
+    id: che-incubator/typescript/1.35.1 
+    memoryLimit: 512Mi
  

--- a/devfiles/openLibertyTemplate/devfile.yaml
+++ b/devfiles/openLibertyTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/openLibertyTemplate/devfile.yaml
+++ b/devfiles/openLibertyTemplate/devfile.yaml
@@ -10,11 +10,14 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+  - alias: java-plugin
+    type: chePlugin
+    id: redhat/java11/0.50.0
   

--- a/devfiles/pythonTemplate/devfile.yaml
+++ b/devfiles/pythonTemplate/devfile.yaml
@@ -10,11 +10,11 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
  

--- a/devfiles/pythonTemplate/devfile.yaml
+++ b/devfiles/pythonTemplate/devfile.yaml
@@ -13,8 +13,8 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
  

--- a/devfiles/springJavaTemplate/devfile.yaml
+++ b/devfiles/springJavaTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/springJavaTemplate/devfile.yaml
+++ b/devfiles/springJavaTemplate/devfile.yaml
@@ -10,11 +10,14 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+  - alias: java-plugin
+    type: chePlugin
+    id: redhat/java11/0.50.0
   

--- a/devfiles/swiftTemplate/devfile.yaml
+++ b/devfiles/swiftTemplate/devfile.yaml
@@ -13,8 +13,8 @@ components:
     id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
   

--- a/devfiles/swiftTemplate/devfile.yaml
+++ b/devfiles/swiftTemplate/devfile.yaml
@@ -10,11 +10,11 @@ projects:
 components:
   - alias: theia-ide
     type: cheEditor
-    id: eclipse/che-theia/7.1.0
+    id: eclipse/che-theia/7.3.1
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.6.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.4.0/meta.yaml
+    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.6.0/meta.yaml
   


### PR DESCRIPTION
This PR updates the devfiles that Che can consume for Codewind 0.6.0:
- Updates Che plugins to 0.6.0 (codewind-theia and codewind-sidecar)
- Updates Theia version to 7.3.1
- Adds LSPs for project types where Che provided one