### PR TITLE
change id to reference

### DIFF
--- a/devfiles/goTemplate/devfile.yaml
+++ b/devfiles/goTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
   - alias: go-plugin
     type: chePlugin
     id: ms-vscode/go/0.11.4

--- a/devfiles/javaMicroProfileTemplate/devfile.yaml
+++ b/devfiles/javaMicroProfileTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/lagomJavaTemplate/devfile.yaml
+++ b/devfiles/lagomJavaTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/nodeExpressTemplate/devfile.yaml
+++ b/devfiles/nodeExpressTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
   - type: chePlugin
     id: che-incubator/typescript/1.35.1 
     memoryLimit: 512Mi

--- a/devfiles/openLibertyTemplate/devfile.yaml
+++ b/devfiles/openLibertyTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/pythonTemplate/devfile.yaml
+++ b/devfiles/pythonTemplate/devfile.yaml
@@ -13,8 +13,8 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
  

--- a/devfiles/springJavaTemplate/devfile.yaml
+++ b/devfiles/springJavaTemplate/devfile.yaml
@@ -13,10 +13,10 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
   - alias: java-plugin
     type: chePlugin
     id: redhat/java11/0.50.0

--- a/devfiles/swiftTemplate/devfile.yaml
+++ b/devfiles/swiftTemplate/devfile.yaml
@@ -13,8 +13,8 @@ components:
     id: eclipse/che-theia/next
   - alias: codewind-sidecar
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-sidecar/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-sidecar/0.10.0/meta.yaml
   - alias: codewind-theia
     type: chePlugin
-    id: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/master/plugins/codewind/codewind-theia/0.8.0/meta.yaml
+    reference: https://raw.githubusercontent.com/eclipse/codewind-che-plugin/0.10.0/plugins/codewind/codewind-theia/0.10.0/meta.yaml
   


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

 starting with Che 7.5.1, the Codewind devfile had to be updated:
- For the two codewind plugins, change id to reference when linking to the Codewind plugin
- The alias for the plugins listed in the devfile, had to match the name given to the plugins